### PR TITLE
configurable checksum file path

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,7 +6,7 @@ Have you ever come across an issue where the traditional `RefreshDatabase` trait
 Traditionally, the `RefreshDatabase` trait will run `php artisan migrate:fresh` every time you run tests. After the first test, it will use transactions to roll back the data and run the next one, so subsequent tests are fast, but the initial test is slow. This can  be really annoying if you are used to running a single test, as it could take seconds to run a single test.
 
 ## The Solution
-You don't need to run `php artisan migrate:fresh` every time you run tests, only when you add a new migration or change an old one. The `FastRefreshDatabase` trait will create a checksum of your `migrations` folder as well as your current Git branch, if you are using Git and will create a `migrationChecksum.txt` file in your application's `storage/app` directory. When your migrations change or your branch changes, the checksum won't match the cached one and `php artisan migrate:fresh` is run.
+You don't need to run `php artisan migrate:fresh` every time you run tests, only when you add a new migration or change an old one. The `FastRefreshDatabase` trait will create a checksum of your `migrations` folder as well as your current Git branch. It will then create a checksum file in your application's `storage/app` directory. When your migrations change or your branch changes, the checksum won't match the cached one and `php artisan migrate:fresh` is run.
 
 When you don't make any changes, it will continue to use the same database without refreshing, which can speed up the test time by 100x!
 
@@ -57,9 +57,20 @@ Just replace the `uses` line in your `Pest.php` file
 +uses(FastRefreshDatabase::class)->in(__DIR__);
 ```
 
-## Deleting MigrationChecksum.txt
+## Deleting The Migration Checksum
 
 Sometimes you may wish to force-update database migrations, to do this, locate the `migrationChecksum.txt` file within `storage/app`.
+
+## Customising the checksum file location
+
+You may customise the migration checksum file location and name by extending the trait and overwriting the `getMigrationChecksumFile()` method.
+
+```php
+protected function getMigrationChecksumFile(): string
+{
+    return storage_path('custom/some-other-file.txt');
+}
+```
  
 ## Known Issues
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -6,7 +6,7 @@ Have you ever come across an issue where the traditional `RefreshDatabase` trait
 Traditionally, the `RefreshDatabase` trait will run `php artisan migrate:fresh` every time you run tests. After the first test, it will use transactions to roll back the data and run the next one, so subsequent tests are fast, but the initial test is slow. This can  be really annoying if you are used to running a single test, as it could take seconds to run a single test.
 
 ## The Solution
-You don't need to run `php artisan migrate:fresh` every time you run tests, only when you add a new migration or change an old one. The `FastRefreshDatabase` trait will create a checksum of your `migrations` folder as well as your current Git branch, if you are using Git and will create a `migrationChecksum.txt` file in your application. When your migrations change or your branch changes, the checksum won't match the cached one and `php artisan migrate:fresh` is run.
+You don't need to run `php artisan migrate:fresh` every time you run tests, only when you add a new migration or change an old one. The `FastRefreshDatabase` trait will create a checksum of your `migrations` folder as well as your current Git branch, if you are using Git and will create a `migrationChecksum.txt` file in your application's `storage/app` directory. When your migrations change or your branch changes, the checksum won't match the cached one and `php artisan migrate:fresh` is run.
 
 When you don't make any changes, it will continue to use the same database without refreshing, which can speed up the test time by 100x!
 
@@ -57,7 +57,12 @@ Just replace the `uses` line in your `Pest.php` file
 +uses(FastRefreshDatabase::class)->in(__DIR__);
 ```
 
-## Ignoring MigrationChecksum.txt
-Next, add "MigrationChecksum.txt" to your .gitignore file. 
+## Deleting MigrationChecksum.txt
 
-Copyright (c) 2022 Plannr Technologies Ltd
+Sometimes you may wish to force-update database migrations, to do this, locate the `migrationChecksum.txt` file within `storage/app`.
+ 
+## Known Issues
+
+### ParaTest Databases
+
+The trait is unaware of what database or environment your tests are running within. Sometimes when running a parallel test after running individual tests, the migration checksum file may not have been deleted. You may have to manually delete the checksum file before running parallel tests.  

--- a/src/Traits/FastRefreshDatabase.php
+++ b/src/Traits/FastRefreshDatabase.php
@@ -103,6 +103,6 @@ trait FastRefreshDatabase
      */
     protected function getMigrationChecksumFile(): string
     {
-        return base_path('migrationChecksum.txt');
+        return storage_path('app/migrationChecksum.txt');
     }
 }

--- a/src/Traits/FastRefreshDatabase.php
+++ b/src/Traits/FastRefreshDatabase.php
@@ -82,7 +82,7 @@ trait FastRefreshDatabase
      */
     protected function getCachedMigrationChecksum(): ?string
     {
-        return rescue(static fn () => file_get_contents(base_path('migrationChecksum.txt')), null, false);
+        return rescue(static fn () => file_get_contents($this->getMigrationChecksumFile()), null, false);
     }
 
     /**
@@ -93,6 +93,16 @@ trait FastRefreshDatabase
      */
     protected function storeMigrationChecksum(string $checksum): void
     {
-        file_put_contents(base_path('migrationChecksum.txt'), $checksum);
+        file_put_contents($this->getMigrationChecksumFile(), $checksum);
+    }
+
+    /**
+     * Provides a configurable migration checksum file path
+     *
+     * @return string
+     */
+    protected function getMigrationChecksumFile(): string
+    {
+        return base_path('migrationChecksum.txt');
     }
 }


### PR DESCRIPTION
Hello! I think that configurable path for checksum file would be helpful for many projects. 

Additionally, if you could reconsider moving it from application root to `bootstrap/cache/whatever-you-want`, installation would be easier as content of  `bootstrap/cache/` is already gitignored in most Laravel projects.