### PR TITLE
Fix | getCachedChecksum method

### DIFF
--- a/src/Traits/FastRefreshDatabase.php
+++ b/src/Traits/FastRefreshDatabase.php
@@ -82,7 +82,7 @@ trait FastRefreshDatabase
      */
     protected function getCachedMigrationChecksum(): ?string
     {
-        return rescue(static fn () => file_get_contents($this->getMigrationChecksumFile()), null, false);
+        return rescue(fn () => file_get_contents($this->getMigrationChecksumFile()), null, false);
     }
 
     /**


### PR DESCRIPTION
Fixes #4 

There was an issue with the `getCachedChecksum()` method because the closure was attempting to call `$this` but the closure was static.