### PR TITLE
Delete Checksum Command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,11 @@
             "Plannr\\Laravel\\FastRefreshDatabase\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Plannr\\Laravel\\FastRefreshDatabase\\Tests\\": "tests"
+        }
+    },
     "authors": [
         {
             "name": "Sam Carré",
@@ -39,6 +44,13 @@
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Plannr\\Laravel\\FastRefreshDatabase\\FastRefreshDatabaseServiceProvider"
+            ]
         }
     }
 }

--- a/src/Commands/DeleteChecksum.php
+++ b/src/Commands/DeleteChecksum.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Plannr\Laravel\FastRefreshDatabase\Commands;
+
+use Illuminate\Console\Command;
+use Plannr\Laravel\FastRefreshDatabase\Traits\FastRefreshDatabase;
+
+class DeleteChecksum extends Command
+{
+    use FastRefreshDatabase;
+
+    public $signature = 'delete-checksum';
+
+    public $description = 'Deletes migration checksum file';
+
+    public function handle()
+    {
+        if (file_exists($this->getMigrationChecksumFile())) {
+            unlink($this->getMigrationChecksumFile())
+                ? $this->info('Checksum deleted successfully.')
+                : $this->error('Unable to delete the checksum.');
+        } else {
+            $this->warn('Nothing to delete.');
+        }
+    }
+}

--- a/src/FastRefreshDatabaseServiceProvider.php
+++ b/src/FastRefreshDatabaseServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Plannr\Laravel\FastRefreshDatabase;
+
+use Illuminate\Support\ServiceProvider;
+
+class FastRefreshDatabaseServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->commands([
+            Commands\DeleteChecksum::class,
+        ]);
+    }
+}

--- a/tests/Commands\DeleteChecksumTest.php
+++ b/tests/Commands\DeleteChecksumTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+
+it('can delete the checksum file', function () {
+    Storage::disk('local')->put('migrationChecksum.txt', 'Contents');
+    Storage::disk('local')->assertExists('migrationChecksum.txt');
+
+    $this->artisan('delete-checksum')->expectsOutputToContain('Checksum deleted successfully.');
+
+    Storage::disk('local')->assertMissing('migrationChecksum.txt');
+});
+
+it('display message when there is no file to delete', function () {
+    $this->artisan('delete-checksum')->expectsOutputToContain('Nothing to delete.');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,6 @@
 */
 
 
-use Plannrc\LaravelFastRefreshDatabase\Traits\FastRefreshDatabase;
+use Plannr\Laravel\FastRefreshDatabase\Tests\TestCase;
 
-uses(FastRefreshDatabase::class)->in(__DIR__);
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Plannr\Laravel\FastRefreshDatabase\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Plannr\Laravel\FastRefreshDatabase\FastRefreshDatabaseServiceProvider;
+
+class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            FastRefreshDatabaseServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a command to delete the checksum file & improve DX when running into issues with ParaTest Databases. Also closes #11.

### TL;DR;
Running the command `delete-checksum` will check if the file exists using the method `$this->getMigrationChecksumFile()` & then proceed to delete it with an output message.

### Changes
- Create Service Provider named `FastRefreshDatabaseServiceProvider` to allow registering commands.
- Update `composer.json` to include the ServiceProvider & autoloading for tests directory.
- Create `tests\TestCase` to allow package testing & update `tests\Pest` to use it.