### PR TITLE
Add symfony/process ^8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/process": "^6.0 || ^7.0"
+        "symfony/process": "^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",


### PR DESCRIPTION
Laravel 13 ships with symfony/process ^8.0, which conflicts with the current constraint. The Process API hasn't changed, so no code updates needed.

Built with AI assistance.